### PR TITLE
Fixing bug in DKG family of shell elements - wrong Bbend sign

### DIFF
--- a/SRC/element/shell/ShellDKGQ.cpp
+++ b/SRC/element/shell/ShellDKGQ.cpp
@@ -1611,6 +1611,12 @@ const Matrix&
 	 Bbend(2,1) = shpBend[3][j] + shpBend[4][j];
 	 Bbend(2,2) = shpBend[3][k] + shpBend[4][k];
 
+     /*
+     bugfix: Massimo Petracca 02/26/2020. with the original implementation, the curvatures
+     sent to the section had the wrong sign.
+     */
+     Bbend *= -1.0;
+
 	 return Bbend;
  }
 

--- a/SRC/element/shell/ShellDKGT.cpp
+++ b/SRC/element/shell/ShellDKGT.cpp
@@ -2036,6 +2036,12 @@ const Matrix&
 	 Bbend(2,1) = shpBend[3][j] + shpBend[4][j];
 	 Bbend(2,2) = shpBend[3][k] + shpBend[4][k];
 
+     /*
+     bugfix: Massimo Petracca 02/26/2020. with the original implementation, the curvatures
+     sent to the section had the wrong sign.
+     */
+     Bbend *= -1.0;
+
 	 return Bbend;
  }
 

--- a/SRC/element/shell/ShellNLDKGQ.cpp
+++ b/SRC/element/shell/ShellNLDKGQ.cpp
@@ -1920,6 +1920,12 @@ const Matrix&
 	 Bbend(2,1) = shpBend[3][j] + shpBend[4][j];
 	 Bbend(2,2) = shpBend[3][k] + shpBend[4][k];
 
+	 /*
+	 bugfix: Massimo Petracca 02/26/2020. with the original implementation, the curvatures
+	 sent to the section had the wrong sign.
+	 */
+	 Bbend *= -1.0;
+
 	 return Bbend;
  }
 //*************************************************************************

--- a/SRC/element/shell/ShellNLDKGQThermal.cpp
+++ b/SRC/element/shell/ShellNLDKGQThermal.cpp
@@ -2206,6 +2206,12 @@ const Matrix&
 	 Bbend(2,1) = shpBend[3][j] + shpBend[4][j];
 	 Bbend(2,2) = shpBend[3][k] + shpBend[4][k];
 
+	 /*
+	 bugfix: Massimo Petracca 02/26/2020. with the original implementation, the curvatures
+	 sent to the section had the wrong sign.
+	 */
+	 Bbend *= -1.0;
+
 	 return Bbend;
  }
 //*************************************************************************

--- a/SRC/element/shell/ShellNLDKGT.cpp
+++ b/SRC/element/shell/ShellNLDKGT.cpp
@@ -1842,6 +1842,12 @@ const Matrix&
 	 Bbend(2,1) = shpBend[3][j] + shpBend[4][j];
 	 Bbend(2,2) = shpBend[3][k] + shpBend[4][k];
 
+	 /*
+	 bugfix: Massimo Petracca 02/26/2020. with the original implementation, the curvatures
+	 sent to the section had the wrong sign.
+	 */
+	 Bbend *= -1.0;
+
 	 return Bbend;
  }
 


### PR DESCRIPTION
DKG  family of shell elements (ShellDKGQ, ShellDKGT, ShellNLDKGQ, ShellNLDKGT and ShellDKGQThermal) show a subtle behaviour in bending only visible when used with LayeredShellSection.
They compute the curvature with a sign which is inverted with respect to what the layered shell expects. However they post-multiply the bending B-matrix so when they compute B^T*S the sign of the internal forces is correct.
However this does not give correct results when used with composite sections, with nonlinear material that behave differently in tension and compression