### PR TITLE
bugfix getCaracteristicLength

### DIFF
--- a/SRC/element/Element.cpp
+++ b/SRC/element/Element.cpp
@@ -681,11 +681,11 @@ double Element::getCharacteristicLength(void)
   for (int i=0; i<numNodes; i++) {
     Node *nodeI = theNodes[i];
     Vector iCoords = nodeI->getCrds();
-    int iDOF = nodeI->getNumberDOF();
+    int iDOF = iCoords.Size(); // nodeI->getNumberDOF(); // bugfix: Massimo Petracca 03/25/2020
     for (int j=i+1; j<numNodes; j++) {
       Node *nodeJ = theNodes[j];
       Vector jCoords = nodeJ->getCrds();      
-      int jDOF = nodeI->getNumberDOF();
+      int jDOF = jCoords.Size(); // nodeI->getNumberDOF(); // bugfix: Massimo Petracca 03/25/2020
       double ijLength = 0;
       for (int k=0; k<iDOF && k<jDOF; k++) {
 	ijLength += (jCoords(k)-iCoords(k))*(jCoords(k)-iCoords(k)); //Tesser


### PR DESCRIPTION
The getCaracteristicLength method in Element.cpp uses the number of DOFs to iterate over the node coordinate components. This is fine as long as the element is a continuum displacement-based element, but in case of beam, shells or UP elements, the number of DOFs is not equal to the coordinate size, thus this function return rubbish or even leads to crashes when invoked on those elements.
The current bufix simply uses the coordinate size vector instead of the number of DOFs.