### PR TITLE
fix: slip direction vector & missing alpha @ commit/revert

### DIFF
--- a/SRC/element/zeroLength/ZeroLengthImplexContact.h
+++ b/SRC/element/zeroLength/ZeroLengthImplexContact.h
@@ -123,29 +123,28 @@ public:
     class StateVariables {
     public:
         // material strain and stress [(0 = normal) (1 = tangent_1) (2 = tangent_2)]
-        Vector eps = Vector(3);        // material strain 
-        Vector eps_commit = Vector(3);        // commited material strain
-        Vector deps = Vector(3);        // strain increment
-        Vector sig = Vector(3);        // contact stress
-        Vector sig_commit = Vector(3);        // commited contact stress
+        Vector eps = Vector(3);             // material strain 
+        Vector eps_commit = Vector(3);      // commited material strain
+        Vector deps = Vector(3);            // strain increment
+        Vector sig = Vector(3);             // contact stress
+        Vector sig_commit = Vector(3);      // commited contact stress
+        double lambda = 0.0;                // slip multiplier
+        double dlambda = 0.0;               // delta slip multiplier
+        double dlambda_commit = 0.0;        // commited delta slip multiplier
+        // state variables for implex
         double alpha = 0.0;
         double alpha_commit = 0.0;
-        double beta = 0.0;              // plastic multiplier (contact)
-        double beta_commit = 0.0;              // commited plastic multiplier
-        double lambda = 0.0;              // slip multiplier
-        double dlambda = 0.0;              // delta slip multiplier
-        double dlambda_commit = 0.0;              // commited delta slip multiplier
-        // state variables for implex
         double alpha_commit_old = 0.0;
-        double beta_commit_old = 0.0;              // prev. commited plastic multiplier
-        double dlambda_commit_old = 0.0;             // prev. commited delta slip multiplier
-        double dtime_n = 0.0;                       // time factor
-        double dtime_n_commit = 0.0;                // commited time factor
+        double beta = 0.0;                  // plastic multiplier (contact)
+        double beta_commit = 0.0;           // commited plastic multiplier
+        double beta_commit_old = 0.0;       // prev. commited plastic multiplier
+        double dlambda_commit_old = 0.0;    // prev. commited delta slip multiplier
+        double dtime_n = 0.0;               // time factor
+        double dtime_n_commit = 0.0;        // commited time factor
         bool dtime_is_user_defined = false;
         bool dtime_first_set = false;
         // modulus
-        bool initial = true;
-        Matrix C = Matrix(3, 3);                  // tangent modulus matrix
+        Matrix C = Matrix(3, 3);            // tangent modulus matrix
         // constructor
         StateVariables(void) = default;
         StateVariables(const StateVariables&) = default;


### PR DESCRIPTION
I found missing statements in the commit method! Also the Vector.Normalize() function while calculating slip_direction vector was not working...